### PR TITLE
Proposal: Show uptime in format like "uptime" on linux console.

### DIFF
--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -51,17 +51,26 @@ class SolrCoreStatus extends AbstractNode
                 $action->setCore($core);
                 $coreAdminQuery->setAction($action);
                 $response = $solr->service->coreAdmin($coreAdminQuery)->getStatusResult();
-                $uptimeInSeconds = floor($response->getUptime() / 1000);
-                $uptime = floor($uptimeInSeconds / 3600) . gmdate(":i:s.", $uptimeInSeconds % 3600) . $response->getUptime() % 1000;
-                $numDocuments = $response->getNumberOfDocuments();
-                $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
-                $lastModified = $response->getLastModified() ? strftime('%c'. $response->getLastModified()->getTimestamp()) : 'N/A';
-                // Create flash message.
-                Helper::addMessage(
-                    sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),
-                    '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
-                    \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
-                );
+                if ($response) {
+                    $uptimeInSeconds = floor($response->getUptime() / 1000);
+                    $dateTimeFrom = new \DateTime('@0');
+                    $dateTimeTo = new \DateTime("@$uptimeInSeconds");
+                    $uptime = $dateTimeFrom->diff($dateTimeTo)->format('%a ' . $GLOBALS['LANG']->getLL('flash.days') . ', %H:%I:%S');
+
+                    $numDocuments = $response->getNumberOfDocuments();
+
+                    $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
+                    $startTimeTimestamp = $response->getStartTime()->getTimestamp();
+
+                    $lastModifiedTimestamp = $response->getLastModified()->getTimestamp();
+                    $lastModified = $response->getLastModified() ? strftime('%c', $response->getLastModified()->getTimestamp()) : 'N/A';
+                    // Create flash message.
+                    Helper::addMessage(
+                        sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),
+                        '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
+                        \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
+                    );
+                }
             } else {
                 // Could not fetch core status.
                 Helper::addMessage(

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -56,13 +56,8 @@ class SolrCoreStatus extends AbstractNode
                     $dateTimeFrom = new \DateTime('@0');
                     $dateTimeTo = new \DateTime("@$uptimeInSeconds");
                     $uptime = $dateTimeFrom->diff($dateTimeTo)->format('%a ' . $GLOBALS['LANG']->getLL('flash.days') . ', %H:%I:%S');
-
                     $numDocuments = $response->getNumberOfDocuments();
-
                     $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
-                    $startTimeTimestamp = $response->getStartTime()->getTimestamp();
-
-                    $lastModifiedTimestamp = $response->getLastModified()->getTimestamp();
                     $lastModified = $response->getLastModified() ? strftime('%c', $response->getLastModified()->getTimestamp()) : 'N/A';
                     // Create flash message.
                     Helper::addMessage(

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -20,6 +20,7 @@
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
             <label index="flash.coreStatus">Start Time: %s&lt;br /&gt;Uptime: %s&lt;br /&gt;Last Modified: %s&lt;br /&gt;Number of Documents: %u</label>
+            <label index="flash.days">days</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
             <label index="flash.newLibrary">New library "%s" [%u] added to database.</label>
@@ -94,6 +95,7 @@
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
             <label index="flash.coreStatus">Startzeit: %s&lt;br /&gt;Laufzeit: %s&lt;br /&gt;Letzte Änderung: %s&lt;br /&gt;Anzahl Dokumente: %u</label>
+            <label index="flash.days">Tage</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>
             <label index="flash.newLibrary">Neue Bibliothek "%s" [%u] zur Datenbank hinzugefügt.</label>


### PR DESCRIPTION
uptime on Linux returns:

  23:41:18 up 4 days,  6:37,  1 user,  load average: 0,91, 0,99, 1,10

The first is the current time, followed by "up", the amount of days
which might be more than a year, followed by h:m.

The proposed output for Solr-uptime would be now:

  Uptime: 0 days, 00:22:56

This includes the seconds, too.

The solution before was:

  Uptime: 0:21:59.385

Which I find harder to read and not self-explaining.